### PR TITLE
Trim path entry in archive when comparing.

### DIFF
--- a/include/Curry/Archive.php
+++ b/include/Curry/Archive.php
@@ -311,7 +311,7 @@ class Curry_Archive implements IteratorAggregate {
 	public function getFile($path)
 	{
 		foreach($this as $entry) {
-			if($entry->getPathname() === $path)
+			if(trim($entry->getPathname()) === $path)
 				return $entry;
 		}
 		throw new Exception("File '$path' not found in archive.");


### PR DESCRIPTION
Archive path entries seems to be stored in a fixed sized string of 100 chars. Hence it is necessary to trim entries when using identical comparisons.