### PR TITLE
Feature modelviewlist sorting

### DIFF
--- a/include/Curry/ModelView/List.php
+++ b/include/Curry/ModelView/List.php
@@ -419,6 +419,11 @@ class Curry_ModelView_List extends Curry_ModelView_Abstract {
 		$allowed = array('title', 'url', 'model', 'paginate', 'maxPerPage', 'currentPage', 'numItems', 'sortable', 'quickSearch', 'actions', 'columns', 'idColumn');
 		$options = array_intersect_key($options, array_flip($allowed));
 
+		if (isset($this->options['defaultSortColumn'])) {
+		    $options['defaultSortColumn'] = $this->options['defaultSortColumn'];
+		    $options['defaultSortOrder'] = isset($this->options['defaultSortOrder']) ? $this->options['defaultSortOrder'] : 'asc';
+		}
+
 		$options = Zend_Json::encode($options, false, array('enableJsonExprFinder' => true));
 		return Curry_Html::createTag('div', array('class' => 'modelview', 'data-modelview' => $options));
 	}

--- a/include/Curry/ModelView/List.php
+++ b/include/Curry/ModelView/List.php
@@ -420,8 +420,8 @@ class Curry_ModelView_List extends Curry_ModelView_Abstract {
 		$options = array_intersect_key($options, array_flip($allowed));
 
 		if (isset($this->options['defaultSortColumn'])) {
-		    $options['defaultSortColumn'] = $this->options['defaultSortColumn'];
-		    $options['defaultSortOrder'] = isset($this->options['defaultSortOrder']) ? $this->options['defaultSortOrder'] : 'asc';
+		    $options['sort_column'] = $this->options['defaultSortColumn'];
+		    $options['sort_order'] = isset($this->options['defaultSortOrder']) ? $this->options['defaultSortOrder'] : 'asc';
 		}
 
 		$options = Zend_Json::encode($options, false, array('enableJsonExprFinder' => true));

--- a/shared/backend/common/css/modelview.css
+++ b/shared/backend/common/css/modelview.css
@@ -178,3 +178,16 @@ a.modelview-delete:hover {
 	background-color: #f5f5f5;
 	height: 100px;
 }
+/* sorting indicators for modelview list column titles */
+.modelview-param.sortable {
+	background-image: linear-gradient(transparent,transparent),url(data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20height%3D%229%22%20width%3D%2221%22%3E%3Crect%20id%3D%22backgroundrect%22%20width%3D%22100%25%22%20height%3D%22100%25%22%20x%3D%220%22%20y%3D%220%22%20fill%3D%22none%22%20stroke%3D%22none%22/%3E%0A%20%20%20%20%0A%3Cg%20class%3D%22currentLayer%22%3E%3Ctitle%3ELayer%201%3C/title%3E%3Cpath%20d%3D%22M14.5%205l-4%204-4-4zM14.5%204l-4-4-4%204z%22%20id%3D%22svg_1%22%20class%3D%22selected%22%20fill-opacity%3D%221%22%20fill%3D%22%23ff6c00%22/%3E%3C/g%3E%3C/svg%3E);
+	background-repeat: no-repeat;
+	background-position: center right;
+	padding-right: 21px;
+}
+.modelview-param.sortable.sort-asc {
+	background-image: linear-gradient(transparent,transparent),url(data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20height%3D%224%22%20width%3D%2221%22%3E%3Crect%20id%3D%22backgroundrect%22%20width%3D%22100%25%22%20height%3D%22100%25%22%20x%3D%220%22%20y%3D%220%22%20fill%3D%22none%22%20stroke%3D%22none%22/%3E%0A%20%20%20%20%0A%3Cg%20class%3D%22currentLayer%22%3E%3Ctitle%3ELayer%201%3C/title%3E%3Cpath%20d%3D%22M6.5%204l4-4%204%204z%22%20id%3D%22svg_1%22%20class%3D%22selected%22%20fill-opacity%3D%221%22%20fill%3D%22%23ff6c00%22/%3E%3C/g%3E%3C/svg%3E);
+}
+.modelview-param.sortable.sort-desc {
+	background-image: linear-gradient(transparent,transparent),url(data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20height%3D%224%22%20width%3D%2221%22%3E%3Crect%20id%3D%22backgroundrect%22%20width%3D%22100%25%22%20height%3D%22100%25%22%20x%3D%220%22%20y%3D%220%22%20fill%3D%22none%22%20stroke%3D%22none%22/%3E%0A%20%20%20%20%0A%3Cg%20class%3D%22currentLayer%22%3E%3Ctitle%3ELayer%201%3C/title%3E%3Cpath%20d%3D%22M14.5%200l-4%204-4-4z%22%20id%3D%22svg_1%22%20class%3D%22selected%22%20fill-opacity%3D%221%22%20fill%3D%22%23ff6c00%22/%3E%3C/g%3E%3C/svg%3E);
+}

--- a/shared/backend/common/js/modelview.js
+++ b/shared/backend/common/js/modelview.js
@@ -87,18 +87,39 @@
 			// Sort/pager
 			base.$el.on('click', '.modelview-param', function() {
 				if ($(this).closest('.modelview')[0] == base.el) {
-					// sort functionality for column titles.
-					if ($(this).hasClass('sort-asc')) {
-						$(this).removeClass('sort-asc').addClass('sort-desc');
-						$(this).attr('href', URI($(this).attr('href')).removeSearch('sort_order').addSearch({sort_order:'desc'}).toString());
-					} else {
-						$(this).removeClass('sort-desc').addClass('sort-asc');
-						$(this).attr('href', URI($(this).attr('href')).removeSearch('sort_order').addSearch({sort_order:'asc'}).toString());
+					if ($(this).hasClass('sortable')) {
+						handleSortableColumnTitle($(this));
 					}
+					
 					base.reload(URI($(this).attr('href')).search(true));
 				}
 				return false;
 			});
+			
+			function handleSortableColumnTitle($el) {
+				// reset indicators to unsorted
+				$el.closest('tr').find(".sortable").not($el).each(function(){
+					$(this).removeClass('sort-asc sort-desc');
+					$(this).attr('href', URI($(this).attr('href')).removeSearch('sort_order').toString());
+				});
+				
+				// TODO: store this element's column title and sort-order in base.options
+				// TODO: we will need this info when we follow pager links.
+				
+				updateSortableColumnTitle($el);
+			}
+			
+			// update a sortable column's indicator and data.
+			function updateSortableColumnTitle($el) {
+				if ($el.hasClass('sort-asc')) {
+					$el.removeClass('sort-asc').addClass('sort-desc');
+					$el.attr('href', URI($el.attr('href')).removeSearch('sort_order').addSearch({sort_order:'desc'}).toString());
+				} else {
+					$el.removeClass('sort-desc').addClass('sort-asc');
+					$el.attr('href', URI($el.attr('href')).removeSearch('sort_order').addSearch({sort_order:'asc'}).toString());
+				}
+			}
+			
 			// Checkbox
 			base.$el.delegate('.modelview-col-select :checkbox', 'change', function() {
 				if ($(this).closest('.modelview')[0] == base.el) {

--- a/shared/backend/common/js/modelview.js
+++ b/shared/backend/common/js/modelview.js
@@ -78,8 +78,8 @@
 			// Model update
 			$(document).on('model-update', function(e, model, id, method) {
 				if (base.options.model == model) {
-					// Reload the grid for the current page.
-					// we don't want the grid resetting to page 1 
+					// Keep current page when reloading grid.
+					// we don't want the grid to reset to page 1 
 					// when an item on the nth page is edited.
 					base.reload({p: base.options.currentPage});
 				}
@@ -224,7 +224,7 @@
 				var column = base.options.columns[i];
 				if (!column.hide) {
 					if (column.sortable) {
-						$content.append($('<th />').append($('<a />', {text: column.label, class: 'modelview-param sortable', href: URI(window.location.href).addSearch({sort_column: i, sort_order: 'asc'})})));
+						$content.append($('<th />').append($('<a />', {text: column.label, class: 'modelview-param sortable'+('defaultSortColumn' in base.options && i == base.options.defaultSortColumn ? ' sort-'+base.options.defaultSortOrder : ''), href: URI(window.location.href).addSearch({sort_column: i, sort_order: 'asc'})})));
 					} else {
 						$content.append($('<th />', {text: column.label}));
 					}

--- a/shared/backend/common/js/modelview.js
+++ b/shared/backend/common/js/modelview.js
@@ -83,8 +83,17 @@
 			});
 			// Sort/pager
 			base.$el.on('click', '.modelview-param', function() {
-				if ($(this).closest('.modelview')[0] == base.el)
+				if ($(this).closest('.modelview')[0] == base.el) {
+					// sort functionality for column titles.
+					if ($(this).hasClass('sort-asc')) {
+						$(this).removeClass('sort-asc').addClass('sort-desc');
+						$(this).attr('href', URI($(this).attr('href')).removeSearch('sort_order').addSearch({sort_order:'desc'}).toString());
+					} else {
+						$(this).removeClass('sort-desc').addClass('sort-asc');
+						$(this).attr('href', URI($(this).attr('href')).removeSearch('sort_order').addSearch({sort_order:'asc'}).toString());
+					}
 					base.reload(URI($(this).attr('href')).search(true));
+				}
 				return false;
 			});
 			// Checkbox
@@ -186,7 +195,7 @@
 				var column = base.options.columns[i];
 				if (!column.hide) {
 					if (column.sortable) {
-						$content.append($('<th />').append($('<a />', {text: column.label, class: 'modelview-param', href: URI(window.location.href).addSearch({sort_column: i, sort_order: 'asc'})})));
+						$content.append($('<th />').append($('<a />', {text: column.label, class: 'modelview-param sortable', href: URI(window.location.href).addSearch({sort_column: i, sort_order: 'asc'})})));
 					} else {
 						$content.append($('<th />', {text: column.label}));
 					}

--- a/shared/backend/common/js/modelview.js
+++ b/shared/backend/common/js/modelview.js
@@ -78,7 +78,10 @@
 			// Model update
 			$(document).on('model-update', function(e, model, id, method) {
 				if (base.options.model == model) {
-					base.reload();
+					// Reload the grid for the current page.
+					// we don't want the grid resetting to page 1 
+					// when an item on the nth page is edited.
+					base.reload({p: base.options.currentPage});
 				}
 			});
 			// Sort/pager

--- a/shared/backend/common/js/modelview.js
+++ b/shared/backend/common/js/modelview.js
@@ -224,7 +224,7 @@
 				var column = base.options.columns[i];
 				if (!column.hide) {
 					if (column.sortable) {
-						$content.append($('<th />').append($('<a />', {text: column.label, class: 'modelview-param sortable'+('defaultSortColumn' in base.options && i == base.options.defaultSortColumn ? ' sort-'+base.options.defaultSortOrder : ''), href: URI(window.location.href).addSearch({sort_column: i, sort_order: 'asc'})})));
+						$content.append($('<th />').append($('<a />', {text: column.label, class: 'modelview-param sortable'+(i == base.options.sort_column ? ' sort-'+base.options.sort_order : ''), href: URI(window.location.href).addSearch({sort_column: i, sort_order: (i == base.options.sort_column ? base.options.sort_order : 'asc')})})));
 					} else {
 						$content.append($('<th />', {text: column.label}));
 					}


### PR DESCRIPTION
This feature adds the following enhancements to Curry CMS:

1.  Add sort indicators to Curry_ModelView_List column headings.
1. The grid's "defaultSort*" options are also supported and indicators will update correctly.
1. Retain sorting status of a column when following pager links.
1. Keep current page when a C_MV_List item is edited (formerly, the grid would reset to page 1).
